### PR TITLE
Remove wrong keyword below "children:"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ You can plug the Ethernet cable into any Internet provider in your home, work, h
   ```YAML
   all:
   children:
-    onionpi:
-      hosts:
-        onionpi:
-          ansible_user: "root"
-          wpa_passphrase: "ENTER_YOUR_PASSPHRASE_HERE"
+    hosts:
+      onionpi:
+        ansible_user: "root"
+        wpa_passphrase: "ENTER_YOUR_PASSPHRASE_HERE"
   ```
 
 * Create an [Ansible playbook](https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html) `onionpi.yml` that will run your Ansible role.


### PR DESCRIPTION
all:
  children:
    onionpi:
      hosts:
        onionpi:
          ansible_user: "root"
          wpa_passphrase: "ENTER_YOUR_PASSPHRASE_HERE"

leads to following output when running ansible-playbook: 

>  [WARNING]: Skipping unexpected key (onionpi) in group (children), only "vars", "children" and "hosts" are valid
>
>  [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
>
>  [WARNING]: Could not match supplied host pattern, ignoring: onionpi
> 
> PLAY [onionpi] ********************************************************************************************************************************
> skipping: no hosts matched
> 
> PLAY RECAP *********************************************************************************************************************************
> 

Removing key "onionpi" below "children" correctly runs playbook.
> 